### PR TITLE
Removendo botão Mostrar Cartas do Admin

### DIFF
--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -165,13 +165,6 @@
           >
             Encerrar <font-awesome-icon icon="hourglass-end" />
           </button>
-          <button
-            type="button"
-            class="btn btn-app margin-bottom margin-left"
-            v-on:click="showCards"
-          >
-            Mostrar Cartas <font-awesome-icon icon="eye" />
-          </button>
         </div>
       </div>
     </div>
@@ -218,9 +211,7 @@ export default {
     },
     finishGame() {
       this.gameStarted = false;
-    },
-    showCards() {
-      this.shouldShowCards = true;
+      this.game = {};
     },
     deleteSession() {
       SessionService.delete(this.session).then(


### PR DESCRIPTION
Botão não faz mais sentido uma vez que as cartas são mostradas automaticamente após todos os usuários aplicarem seus votos (: